### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Key Skills: LLM Orchestration, Autonomous Workflows, System Design, Automated Re
 
 **Dependencies (`requirements.txt`):**
 The `requirements.txt` file lists all Python libraries needed to run this project. Key libraries include:
-- `pyautogen`, `autogen-agentchat`, `autogen-ext`: For building and managing the multi-agent system. `autogen-ext[openai]` specifically enables the use of OpenAI-compatible APIs like Google's Gemini.
+- `ag2`, `autogen-agentchat`, `autogen-ext`: For building and managing the multi-agent system. `autogen-ext[openai]` specifically enables the use of OpenAI-compatible APIs like Google's Gemini.
 - `rich`: For creating rich, formatted text and tables in the console output.
 - `nest-asyncio`: To allow asyncio to run in environments like Jupyter notebooks or standard Python scripts where an event loop might already be running.
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -82,7 +82,7 @@ graph TD
 
 **의존성 (`requirements.txt`):**
 `requirements.txt` 파일은 이 프로젝트를 실행하는 데 필요한 모든 Python 라이브러리를 나열합니다. 주요 라이브러리는 다음과 같습니다:
-- `pyautogen`, `autogen-agentchat`, `autogen-ext`: 멀티 에이전트 시스템 구축 및 관리를 위한 라이브러리입니다. 특히 `autogen-ext[openai]`는 Google Gemini와 같은 OpenAI 호환 API 사용을 가능하게 합니다.
+- `ag2`, `autogen-agentchat`, `autogen-ext`: 멀티 에이전트 시스템 구축 및 관리를 위한 라이브러리입니다. 특히 `autogen-ext[openai]`는 Google Gemini와 같은 OpenAI 호환 API 사용을 가능하게 합니다.
 - `rich`: 콘솔 출력에서 서식이 풍부한 텍스트와 표를 만드는 데 사용됩니다.
 - `nest-asyncio`: Jupyter 노트북이나 표준 Python 스크립트와 같이 이미 이벤트 루프가 실행 중일 수 있는 환경에서 asyncio를 실행할 수 있도록 합니다.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requirements.txt
 Core autogen libraries
-pyautogen
+ag2
 autogen-agentchat
 autogen-ext
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
